### PR TITLE
Fix map marker anchor so coordinate falls on the bubble tip (#29)

### DIFF
--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -15,8 +15,8 @@ const CELL_SIZE = 0.05;                 // ~5.5 km per grid cell
 const MIN_FETCH_RADIUS_KM = Math.ceil(CELL_SIZE * 111 * 1.5);
 const MEXICO_BOUNDS = L.latLngBounds([14.5, -118.5], [32.8, -86.5]);
 
-const markerIcon = L.icon({ iconUrl: '/assets/img/PING1.svg', iconSize: [49, 54] });
-const markerIconSelected = L.icon({ iconUrl: '/assets/img/PING2.svg', iconSize: [63, 70] });
+const markerIcon = L.icon({ iconUrl: '/assets/img/PING1.svg', iconSize: [49, 54], iconAnchor: [24, 43], popupAnchor: [0, -38] });
+const markerIconSelected = L.icon({ iconUrl: '/assets/img/PING2.svg', iconSize: [63, 70], iconAnchor: [32, 58], popupAnchor: [0, -50] });
 
 // ---- State ----------------------------------------------------------------
 
@@ -124,7 +124,7 @@ async function fetchAllPages(firstURL, fetchId, onPage) {
 function createMarkerObj(pudo) {
 	const { latitude, longitude } = pudo.address.coordinate;
 	const marker = L.marker([latitude, longitude], { icon: markerIcon });
-	marker.bindPopup(buildPopupHTML(pudo), { offset: L.point(0, -20) });
+	marker.bindPopup(buildPopupHTML(pudo));
 	return marker;
 }
 


### PR DESCRIPTION
## Problem

PUDO markers on the web map used Leaflet's default anchor (the icon center), so the coordinate appeared at the center of the bubble instead of at its downward pointer. At high zoom this was misleading — especially for corner PUDOs, where the marker could seem to sit on the wrong sidewalk/street.

## Fix

Anchored the icon to the actual tip of the bubble. The anchor is in image pixels, so it is zoom-invariant — no per-zoom logic needed. The square-icon fallback from the issue was unnecessary.

- Set `iconAnchor` to the bubble tip for both the default (`PING1`) and selected (`PING2`) icons, computed from each SVG's viewBox/tip vertex.
- Added matching `popupAnchor` so the info popup still opens above the bubble.
- Dropped the now-redundant `offset` on `bindPopup`.

## Verification

Confirmed visually with a temporary red dot at the exact coordinate: the bubble tip lands on the dot at maximum zoom. Debug code removed before commit.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)