### PR TITLE
Pack cards: use the API "popular" field and drop the duplicated guides line (#48)

### DIFF
--- a/assets/js/packs.js
+++ b/assets/js/packs.js
@@ -39,8 +39,6 @@ const escapeHtml = (value) =>
 		"'": '&#39;',
 	})[char]);
 
-const guidesLabel = (credits) => (credits === 1 ? '1 guía' : formatNumber(credits) + ' guías');
-
 const perUnitLabel = (pack) => {
 	const unit = pack.price / pack.credits;
 	const rounded = Number.isInteger(unit) ? unit : Number(unit.toFixed(2));
@@ -58,7 +56,6 @@ const packBullet = (pack, index, referenceUnitPrice) => {
 const renderPack = (pack, index, referenceUnitPrice) => {
 	const name = escapeHtml(pack.name);
 	const currency = escapeHtml(pack.currency);
-	const guides = guidesLabel(pack.credits);
 	const price = formatNumber(pack.price);
 	const perUnit = perUnitLabel(pack);
 	const bullet = escapeHtml(packBullet(pack, index, referenceUnitPrice));
@@ -67,10 +64,9 @@ const renderPack = (pack, index, referenceUnitPrice) => {
 		return `
 			<div class="pack-card bg-primary text-white rounded-4 border border-primary p-4 d-flex flex-column text-start position-relative shadow">
 				<span class="badge text-bg-secondary text-dark fw-bold rounded-pill position-absolute top-0 start-50 translate-middle px-3 py-2">MÁS POPULAR</span>
-				<div class="mb-1">
+				<div class="mb-3">
 					<span class="fw-bold fs-5">${name}</span>
 				</div>
-				<div class="fs-6 fw-medium opacity-75 mb-3">${guides}</div>
 				<div class="mb-1 lh-1">
 					<span class="fw-bold display-6">$${price}</span>
 					<span class="fs-6 fw-medium opacity-75">${currency}</span>
@@ -87,10 +83,9 @@ const renderPack = (pack, index, referenceUnitPrice) => {
 
 	return `
 		<div class="pack-card bg-white rounded-4 border border-light-subtle p-4 d-flex flex-column text-start">
-			<div class="mb-1">
+			<div class="mb-3">
 				<span class="fw-bold fs-5">${name}</span>
 			</div>
-			<div class="fs-6 fw-medium text-black-50 mb-3">${guides}</div>
 			<div class="mb-1 lh-1">
 				<span class="fw-bold display-6 text-primary">$${price}</span>
 				<span class="fs-6 fw-medium text-black-50">${currency}</span>

--- a/assets/js/packs.js
+++ b/assets/js/packs.js
@@ -20,11 +20,10 @@ const loadPacks = async () => {
 		return;
 	}
 
-	const popularIndex = Math.floor(items.length / 2);
 	const referenceUnitPrice = items[0].price / items[0].credits;
 
 	const cards = items
-		.map((pack, index) => renderPack(pack, index, popularIndex, referenceUnitPrice))
+		.map((pack, index) => renderPack(pack, index, referenceUnitPrice))
 		.join('');
 	list.insertAdjacentHTML('beforeend', cards);
 };
@@ -56,7 +55,7 @@ const packBullet = (pack, index, referenceUnitPrice) => {
 	return 'Ahorras $' + formatNumber(saving) + ' vs. compra individual';
 };
 
-const renderPack = (pack, index, popularIndex, referenceUnitPrice) => {
+const renderPack = (pack, index, referenceUnitPrice) => {
 	const name = escapeHtml(pack.name);
 	const currency = escapeHtml(pack.currency);
 	const guides = guidesLabel(pack.credits);
@@ -64,7 +63,7 @@ const renderPack = (pack, index, popularIndex, referenceUnitPrice) => {
 	const perUnit = perUnitLabel(pack);
 	const bullet = escapeHtml(packBullet(pack, index, referenceUnitPrice));
 
-	if (index === popularIndex) {
+	if (pack.popular) {
 		return `
 			<div class="pack-card bg-primary text-white rounded-4 border border-primary p-4 d-flex flex-column text-start position-relative shadow">
 				<span class="badge text-bg-secondary text-dark fw-bold rounded-pill position-absolute top-0 start-50 translate-middle px-3 py-2">MÁS POPULAR</span>


### PR DESCRIPTION
Closes #48

## Changes

- **Popular badge from the API**: the "MÁS POPULAR" badge is now placed on the pack whose `popular` boolean is `true` in the `/api/web/v1/packs` response, instead of assuming the middle pack of the list. Production already returns the field (currently `true` on the 50-guide pack, the last one), so this also fixes the badge being shown on the wrong pack.
- **No duplicated guides line**: the front-built "N guías" string is removed from the cards, since pack names coming from the API now carry that same text. Cards show the API `name`, the price and the per-guide price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)