### PR TITLE
Simplificar sección de autenticación de la guía API

### DIFF
--- a/api-integration/index.html
+++ b/api-integration/index.html
@@ -68,11 +68,10 @@ toc:
         Endpoints implicados:
     </p>
     <ul class="text-body-secondary mb-4">
-        <li class="mb-2"><code>POST /api/auth/v1/users/merchant</code> — alta de usuario merchant (solo la primera vez).</li>
         <li><code>POST /api/v1/auth/login</code> — obtención del token de acceso.</li>
     </ul>
     <p class="text-body-secondary mb-0">
-        Guarda el token de forma segura y rótalo de acuerdo con tus políticas internas. El rol necesario para operar con la API de merchant es <code>ROLE_MERCHANT</code>.
+        Guarda el token de forma segura y rótalo de acuerdo con tus políticas internas.
     </p>
 </section>
 


### PR DESCRIPTION
## Resumen

Ajusta el copy de la sección **Autenticación** de `/api-integration/`:

- Quita el endpoint `POST /api/auth/v1/users/merchant` (alta de usuario) — el alta se hace off-band durante el onboarding, no la ejecuta el integrador.
- Quita la mención a `ROLE_MERCHANT` — es un detalle interno que no aporta al integrador.

## Test plan

- [ ] Verificar en `/api-integration/#autenticacion` que solo se lista el endpoint de login y que el párrafo final termina en "políticas internas".

🤖 Generated with [Claude Code](https://claude.com/claude-code)